### PR TITLE
adds getBlock endpoint with stubbed version of `lightBlock` implementation

### DIFF
--- a/protos/lightstreamer.proto
+++ b/protos/lightstreamer.proto
@@ -3,6 +3,42 @@ package lightstreamer;
 
 message Empty {}
 
+message BlockID {
+     optional uint64 sequence = 1;
+     optional bytes hash = 2;
+}
+
+message LightBlock {
+	uint32 protoVersion = 1;    // the version of this wire format, for storage
+    uint64 sequence = 2;          // the height of this block
+    bytes hash = 3;             // the ID (hash) of this block, same as explorer
+    bytes previousBlockHash = 4;         // the ID (hash) of this block's predecessor
+    uint32 timestamp = 5;            // Unix epoch time when the block was mined
+    repeated LightTransaction transactions = 6; // zero or more compact transactions from this block
+}
+
+message LightTransaction {
+    uint64 index = 1; // do we need this field?
+    bytes hash = 2;
+
+    repeated LightSpend spends = 4;
+    repeated LightOutput outputs = 5;
+}
+
+
+message LightSpend {
+    bytes nf = 2;
+}
+
+message LightOutput {
+    bytes note = 1; // NoteEncrypted, serialized
+}
+
+
+message Transaction {
+	// same structure as ironfish/src/primitives/transaction.ts
+}
+
 message ServerInfo {
  string version = 1;
  string vendor = 2;
@@ -15,4 +51,5 @@ message ServerInfo {
 
 service LightStreamer {
  rpc GetServerInfo(Empty) returns (ServerInfo) {}
+ rpc GetBlock(BlockID) returns (LightBlock) {}
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -15,3 +15,13 @@ client.getServerInfo(Empty, (error, response) => {
 
   console.info(response);
 });
+
+client.getBlock({ sequence: 5 }, (error, response) => {
+  if (error) {
+    console.error(error);
+
+    process.exit(1);
+  }
+
+  console.info(response);
+})

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,7 @@ import { LightStreamer, LightStreamerService } from "./services/LightStreamer";
 import { logger } from "./utils";
 import { config } from "dotenv";
 
-config({ path: process.env["DOTENV_PATH"] || ".env" });
+config({ path: process.env['DOTENV_PATH']} || '.env');
 
 const server = new Server({
   "grpc.max_receive_message_length": -1,

--- a/src/utils/light_block.ts
+++ b/src/utils/light_block.ts
@@ -1,0 +1,37 @@
+import { GetBlockResponse, FollowChainStreamResponse } from '@ironfish/sdk'
+import { LightBlock, LightOutput, LightSpend, LightTransaction } from "src/models/lightstreamer"
+
+export function lightBlock(response: FollowChainStreamResponse | GetBlockResponse): LightBlock {
+	let lightTransactions: LightTransaction[] = []
+    let previousBlockHash = 'previous' in response.block ? response.block.previous : response.block.previousBlockHash
+	for (let index = 0; index < response.block.transactions.length; index++) {
+        const rpcTransaction = response.block.transactions[index]
+        let lightSpends: LightSpend[] = []
+		let lightOutputs: LightOutput[] = []
+		
+        // Stubbed until changes in @ironfish/sdk are released
+        // const serialized = ''
+        // if (rpcTransaction.serialized === undefined) {
+        //     throw new Error("Transaction is missing serialized data")
+        // }
+        // const serialized = rpcTransaction.serialized
+        // let transaction	= new Transaction(Buffer.from(serialized, 'hex'))
+		// for (const spend of transaction.spends) {
+		// 	lightSpends.push({nf: spend.nullifier})
+		// }
+		// for (const note of transaction.notes) {
+		// 	lightOutputs.push({note: note.serialize()})
+		// }
+		lightTransactions.push(
+			{index, hash: Buffer.from(rpcTransaction.hash, 'hex'), spends: lightSpends, outputs: lightOutputs}
+		)
+	}
+	return {
+        protoVersion: 1,
+        sequence: response.block.sequence,
+        hash: Buffer.from(response.block.hash, 'hex'),
+        previousBlockHash: Buffer.from(previousBlockHash, 'hex'),
+		timestamp: response.block.timestamp,
+		transactions: lightTransactions
+    }
+}


### PR DESCRIPTION
Tested locally, waiting for unit test framework:

```
╰─ yarn client
yarn run v1.22.19
$ node dist/client
{
  version: '0',
  vendor: 'IF Labs',
  networkId: '1',
  nodeVersion: '1.7.0',
  nodeStatus: 'started',
  blockHeight: 152322,
  blockHash: '000000000000001ee149dac9f0899e6ae6183830fc4d37b7551cb73b0a3667aa'
}
{
  protoVersion: 1,
  sequence: 5,
  hash: <Buffer 00 00 00 00 00 00 00 2f c1 33 e6 06 b9 81 a3 05 4f 05 02 ee f9 c4 ec 47 3a db 76 71 ef 14 56 ee>,
  previousBlockHash: <Buffer 00 00 00 00 00 00 00 40 f7 43 e5 7e 78 54 eb 63 97 02 ea a3 af 5b 5b e2 b4 8a 4f b2 a8 5d 77 08>,
  timestamp: 2675919337,
  transactions: [
    {
      index: 0,
      hash: <Buffer 19 45 fe d3 f6 38 be 4b 22 b6 66 b9 5d c7 74 f3 6a f8 e9 98 4f c9 6f a6 a8 eb 50 4f 67 71 0b 06>,
      spends: [],
      outputs: []
    }
  ]
}
```