### PR TITLE
feat: get block range additions for grpc

### DIFF
--- a/protos/lightstreamer.proto
+++ b/protos/lightstreamer.proto
@@ -8,6 +8,13 @@ message BlockID {
      optional bytes hash = 2;
 }
 
+// BlockRange specifies a series of blocks from start to end inclusive.
+// Both BlockIDs must be sequences; specification by hash is not yet supported.
+message BlockRange {
+    BlockID start = 1;
+    BlockID end = 2;
+}
+
 message LightBlock {
 	uint32 protoVersion = 1;    // the version of this wire format, for storage
     uint64 sequence = 2;          // the height of this block
@@ -53,4 +60,5 @@ service LightStreamer {
  rpc GetServerInfo(Empty) returns (ServerInfo) {}
  rpc GetLatestBlock(Empty) returns (BlockID) {}
  rpc GetBlock(BlockID) returns (LightBlock) {}
+ rpc GetBlockRange(BlockRange) returns (stream LightBlock) {}
 }

--- a/src/cache/index.test.slow.ts
+++ b/src/cache/index.test.slow.ts
@@ -11,6 +11,7 @@ afterAll(async () => {
 
 describe("LightBlockCache creating cache", () => {
   it("creating the cache adds blocks", async () => {
+    await lightBlockCache.clear();
     const cacheBlocks = lightBlockCache.cacheBlocks();
     await Promise.race([cacheBlocks, delay()]);
     const head = await lightBlockCache.get("head");

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -92,6 +92,10 @@ class LightBlockCache {
   async close(): Promise<void> {
     await this.db.close();
   }
+
+  async clear(): Promise<void> {
+    await this.db.clear();
+  }
 }
 
 export const lightBlockCache = new LightBlockCache();


### PR DESCRIPTION
Adds `getBlockRange` endpoint. 

- Streams blocks back as retrieved
- Errors if: block ranges are inverted, block can't be found, hash is attempted to be used