### PR TITLE
adds send transaction endpoint

### DIFF
--- a/protos/lightstreamer.proto
+++ b/protos/lightstreamer.proto
@@ -43,7 +43,13 @@ message LightOutput {
 
 
 message Transaction {
-	// same structure as ironfish/src/primitives/transaction.ts
+    // built, encrypted transaction
+    bytes data = 1;
+}
+
+message SendResponse {
+    bytes hash = 1;
+    bool accepted = 2;
 }
 
 message ServerInfo {
@@ -61,4 +67,5 @@ service LightStreamer {
  rpc GetLatestBlock(Empty) returns (BlockID) {}
  rpc GetBlock(BlockID) returns (LightBlock) {}
  rpc GetBlockRange(BlockRange) returns (stream LightBlock) {}
+ rpc SendTransaction(Transaction) returns (SendResponse) {}
 }

--- a/src/services/LightStreamer.ts
+++ b/src/services/LightStreamer.ts
@@ -11,6 +11,8 @@ import {
   LightBlock,
   BlockID,
   BlockRange,
+  Transaction,
+  SendResponse,
 } from "@/models/lightstreamer";
 import { ifClient } from "@/utils/ironfish";
 import { lightBlock } from "@/utils/lightBlock";
@@ -26,6 +28,28 @@ class LightStreamer implements LightStreamerServer {
     callback(null, {
       sequence: Number(response.content.currentBlockIdentifier.index),
       hash: Buffer.from(response.content.currentBlockIdentifier.hash, "hex"),
+    });
+  });
+  public sendTransaction = handle<Transaction, SendResponse>(async (
+    call,
+    callback,
+  ) => {
+    const rpcClient = await ifClient.getClient();
+    const response = await rpcClient.chain.broadcastTransaction({
+      transaction: call.request.data.toString("hex"),
+    });
+    if (!response.content) {
+      callback(
+        new Error(
+          "No data was returned when trying to broadcast the transaction",
+        ),
+        null,
+      );
+      return;
+    }
+    callback(null, {
+      accepted: response.content.accepted,
+      hash: Buffer.from(response.content.hash, "hex"),
     });
   });
 

--- a/test/server.test.slow.ts
+++ b/test/server.test.slow.ts
@@ -5,6 +5,7 @@ import {
   Empty,
   LightBlock,
   LightStreamerClient,
+  SendResponse,
   ServerInfo,
 } from "@/models/lightstreamer";
 import { lightBlockCache } from "@/cache";
@@ -190,6 +191,22 @@ describe("getBlock", () => {
         reject(error);
       });
     });
+    expect(promise).rejects.toThrow("INTERNAL: ");
+  });
+
+  it("sendTransaction fails with invalid data", async () => {
+    const promise = new Promise<SendResponse>((resolve, reject) => {
+      client.sendTransaction(
+        { data: Buffer.from("invalid transaction", "hex") },
+        (err, response) => {
+          if (err) {
+            reject(err);
+          }
+          resolve(response);
+        },
+      );
+    });
+
     expect(promise).rejects.toThrow("INTERNAL: ");
   });
 });


### PR DESCRIPTION
Send encrypted/built transaction as bytes to network.

Response is whether node accepted along with the calculated transaction hash.

Testing here would be difficult because there is validation that is required for transaction to be valid. Also we would need to construct the transaction which would require the client implementation for building.