### PR TITLE
adds merkle tree example using ironfish merkle tree implementation

### DIFF
--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -3,7 +3,7 @@ import { LightStreamerClient } from "../../src/models/lightstreamer";
 import { BlockProcessor } from "./utils/BlockProcessor";
 
 const client = new LightStreamerClient(
-  "localhost:50051",
+  process.env["WALLET_SERVER_HOST"] || "localhost:50051",
   credentials.createInsecure(),
 );
 

--- a/example/src/merkle/merkle.ts
+++ b/example/src/merkle/merkle.ts
@@ -1,0 +1,25 @@
+import { NoteHasher } from "@ironfish/sdk/build/src/merkletree/hasher";
+import { MerkleTree } from "@ironfish/sdk/build/src/merkletree/merkletree";
+import { BUFFER_ENCODING } from "@ironfish/sdk/build/src/storage";
+import { createDB } from "@ironfish/sdk/build/src/storage/utils";
+import { LeafEncoding } from "@ironfish/sdk/build/src/merkletree/database/leaves";
+import { NodeEncoding } from "@ironfish/sdk/build/src/merkletree/database/nodes";
+import { NoteEncrypted } from "@ironfish/sdk/build/src/primitives/noteEncrypted";
+
+const db = createDB({ location: "./testdb" });
+db.open();
+
+const notesTree = new MerkleTree({
+  hasher: new NoteHasher(),
+  leafIndexKeyEncoding: BUFFER_ENCODING,
+  leafEncoding: new LeafEncoding(),
+  nodeEncoding: new NodeEncoding(),
+  db,
+  name: "n",
+  depth: 32,
+  defaultValue: Buffer.alloc(32),
+});
+
+export const addNotesToMerkleTree = async (notes: NoteEncrypted[]) => {
+  return notesTree.addBatch(notes);
+};

--- a/example/src/utils/BlockProcessor.ts
+++ b/example/src/utils/BlockProcessor.ts
@@ -6,10 +6,7 @@ import {
   LightStreamerClient,
 } from "../../../src/models/lightstreamer";
 import { ServiceError } from "@grpc/grpc-js";
-
-function addToMerkleTree(note: NoteEncrypted) {
-  return note;
-}
+import { addNotesToMerkleTree } from "../merkle/merkle";
 
 const POLL_INTERVAL = 30 * 1000;
 
@@ -96,6 +93,7 @@ export class BlockProcessor {
   }
 
   private async _processBlockRange(startSequence: number, endSequence: number) {
+    let blocksProcessed = startSequence;
     const stream = this.client.getBlockRange({
       start: {
         sequence: startSequence,
@@ -109,6 +107,10 @@ export class BlockProcessor {
       await new Promise((res) => {
         stream.on("data", (block: LightBlock) => {
           this._processBlock(block);
+          blocksProcessed++;
+          if (blocksProcessed % 100 === 0) {
+            console.log(`Processed ${blocksProcessed}/${endSequence} blocks`);
+          }
         });
 
         stream.on("end", () => {
@@ -120,13 +122,15 @@ export class BlockProcessor {
     }
   }
 
-  private _processBlock(block: LightBlock) {
+  private async _processBlock(block: LightBlock) {
+    const notes: NoteEncrypted[] = [];
     for (const transaction of block.transactions) {
       for (const output of transaction.outputs) {
         const note = new NoteEncrypted(output.note);
-        addToMerkleTree(note);
+        notes.push(note);
       }
     }
+    await addNotesToMerkleTree(notes);
 
     this.lastProcessedBlock = block.sequence;
   }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -48,6 +48,9 @@ class LightBlockCache {
     });
 
     for await (const content of stream.contentStream()) {
+      if (content.block.sequence % 1000 === 0) {
+        logger.info(`Caching block ${content.block.sequence}`);
+      }
       if (content.type === "connected") {
         if (content.block.sequence % 1000 === 0) {
           logger.info(


### PR DESCRIPTION
Uses the merkle tree of `ironfish` to create a stored tree on the backend. This will allow us to calculate the witness for spends.

Currently does not handle reorgs, only consecutive block additions.