### PR TITLE
add note size to light block for client utility

### DIFF
--- a/protos/lightstreamer.proto
+++ b/protos/lightstreamer.proto
@@ -22,6 +22,8 @@ message LightBlock {
     bytes previousBlockHash = 4;         // the ID (hash) of this block's predecessor
     uint32 timestamp = 5;            // Unix epoch time when the block was mined
     repeated LightTransaction transactions = 6; // zero or more compact transactions from this block
+    uint64 noteSize = 7; // the size of the notes tree after adding transactions from this block.
+
 }
 
 message LightTransaction {

--- a/src/utils/lightBlock.ts
+++ b/src/utils/lightBlock.ts
@@ -13,6 +13,9 @@ import {
 export function lightBlock(
   response: FollowChainStreamResponse | GetBlockResponse,
 ): LightBlock {
+  if (!response.block.noteSize) {
+    throw new Error("Block is missing noteSize");
+  }
   const lightTransactions: LightTransaction[] = [];
   const previousBlockHash =
     "previous" in response.block
@@ -50,5 +53,6 @@ export function lightBlock(
     previousBlockHash: Buffer.from(previousBlockHash, "hex"),
     timestamp: response.block.timestamp,
     transactions: lightTransactions,
+    noteSize: response.block.noteSize,
   };
 }


### PR DESCRIPTION
Note size allows us to determine the total number of notes at a given point in the chain (for calculating the witness in the merkle tree). This could be done on the fly, but would require a bunch of replicated logic from the node. Including it in the block headers (like it is done in the RPC) simplifies things.