### PR TITLE
chore: minor changes to client and server logic

### DIFF
--- a/example/.env.example
+++ b/example/.env.example
@@ -1,1 +1,2 @@
 SPENDING_KEY=""
+WALLET_SERVER_HOST="walletserver.ironfish.network:50051"

--- a/example/src/Client/Client.ts
+++ b/example/src/Client/Client.ts
@@ -5,7 +5,7 @@ import { AccountsManager } from "./utils/AccountsManager";
 import { BlockCache } from "./utils/BlockCache";
 
 const client = new LightStreamerClient(
-  "localhost:50051",
+  process.env["WALLET_SERVER_HOST"] ?? "localhost:50051",
   credentials.createInsecure(),
 );
 

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,7 +1,7 @@
 import { config } from "dotenv";
-import { Client } from "./Client/Client";
-
 config();
+
+import { Client } from "./Client/Client";
 
 async function main() {
   const client = new Client();

--- a/test/server.test.slow.ts
+++ b/test/server.test.slow.ts
@@ -184,7 +184,7 @@ describe("getBlock", () => {
       });
     });
     expect(promise).rejects.toThrow(
-      "INVALID_ARGUMENT: End sequence must be greater than start sequence",
+      "INVALID_ARGUMENT: End sequence must be greater than or equal to start sequence",
     );
   });
 


### PR DESCRIPTION
Client:
- provides optional env var for server to interact with

Server
- catches edge case where `0` is provided for end/start in get block range
- catches error where getBlockRange `start===end`
- Adds `BLOCK_RANGE_MAX` env var for gating max number of blocks that can be requested (effectively rate limiting)