### PR TITLE
feat: wait function for account/processor

### DIFF
--- a/example/src/Client/Client.ts
+++ b/example/src/Client/Client.ts
@@ -22,7 +22,22 @@ export class Client {
   }
 
   public addAccount(privateKey: string) {
-    this.accountsManager.addAccount(privateKey);
+    return this.accountsManager.addAccount(privateKey);
+  }
+
+  public async waitForProcessorSync() {
+    await this.blockProcessor.waitForProcessorSync();
+  }
+
+  public async waitForAccountSync(publicAddress: string) {
+    await this.waitForProcessorSync();
+    console.log(
+      `Processor synced. Waiting for account ${publicAddress} to sync`,
+    );
+
+    const head = await this.blockCache.getHeadSequence();
+    await this.accountsManager.waitForAccountSync(publicAddress, head);
+    console.log(`Account ${publicAddress} synced to head ${head}`);
   }
 
   public async start() {

--- a/example/src/Client/utils/AccountsManager.ts
+++ b/example/src/Client/utils/AccountsManager.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from "events";
+
 import {
   generateKeyFromPrivateKey,
   Key,
@@ -24,6 +26,7 @@ export interface DecryptedNoteValue {
 
 interface AccountData {
   key: Key;
+  head: number;
   assets: Map<
     string,
     {
@@ -37,13 +40,15 @@ export class AccountsManager {
   private blockCache: BlockCache;
   /** publicKey => AccountData */
   private accounts: Map<string, AccountData> = new Map();
+  private events: EventEmitter = new EventEmitter();
 
   constructor(blockCache: BlockCache) {
     this.blockCache = blockCache;
   }
 
   public addAccount(privateKey: string) {
-    this.accounts.set(...this._makeAccountData(privateKey));
+    const accountData = this._makeAccountData(privateKey);
+    this.accounts.set(...accountData);
 
     this.blockCache
       .createReadStream()
@@ -53,7 +58,42 @@ export class AccountsManager {
           return;
         }
         this._processBlockForTransactions(value);
+        this.events.emit("accounts-updated");
       });
+
+    return accountData[0];
+  }
+
+  public waitForAccountSync(
+    publicAddress: string,
+    sequence: number,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const checkSequence = () => {
+        const accountData = this.accounts.get(publicAddress);
+        if (!accountData) {
+          this.events.removeListener("accounts-updated", checkSequence);
+          return reject(
+            new Error(`Account with public address ${publicAddress} not found`),
+          );
+        }
+        logThrottled(
+          `Waiting for account sync to complete, ${accountData.head}/${sequence}`,
+          1000,
+          accountData.head,
+        );
+        if (accountData.head >= sequence) {
+          this.events.removeListener("accounts-updated", checkSequence);
+          return resolve();
+        }
+      };
+
+      // Check initially
+      checkSequence();
+
+      // Listen for account updates
+      this.events.on("accounts-updated", checkSequence);
+    });
   }
 
   public getPublicAddresses() {
@@ -66,6 +106,7 @@ export class AccountsManager {
       key.publicAddress,
       {
         key,
+        head: 0,
         assets: new Map(),
       },
     ];
@@ -86,6 +127,10 @@ export class AccountsManager {
 
       // @todo: Process spends
     });
+
+    for (const [_, account] of this.accounts) {
+      account.head = parsedBlock.sequence;
+    }
   }
 
   private _processNote(

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -13,7 +13,10 @@ async function main() {
     throw new Error("SPENDING_KEY not found");
   }
 
-  client.addAccount(spendingKey);
+  const publicAddress = client.addAccount(spendingKey);
+  console.log("Added account");
+  await client.waitForAccountSync(publicAddress);
+  console.log("Account synced");
 
   await client.waitUntilClose();
 }


### PR DESCRIPTION
Creates a `wait` command for both accounts and blockprocessor, example output:

```
yarn dev
yarn run v1.22.19
$ ts-node src/index.ts
Added account
Waiting for processor to sync
Processor synced. Waiting for account 829f03a4c9f9702e269d5b63cde81cfe0e2389694cfc668a71b1b06bbebfb296 to sync
Waiting for sync to complete, 0/200219
Processing blocks from 200219 to 200221
Finished processing blocks
Waiting for sync to complete, 1000/200219
Waiting for sync to complete, 2000/200219
Waiting for sync to complete, 3000/200219
```