### PR TITLE
Remove head sequence check from AccountsManager

### DIFF
--- a/example/src/Client/utils/send.ts
+++ b/example/src/Client/utils/send.ts
@@ -82,7 +82,7 @@ async function fundTransaction(
     ) {
       continue;
     }
-    const witness = await notesTree.witness(note.merkleIndex, 130379);
+    const witness = await notesTree.witness(note.merkleIndex);
     console.log(
       note.note.hash().toString("hex"),
       note.sequence,


### PR DESCRIPTION
On my chain shorter than the hardcoded block size, the client was early-exiting. We should be able to just wait for the read stream to finish, then let any event subscribers know that the sync is done.