### PR TITLE
Roll back merkle tree if note size mismatch

### DIFF
--- a/example/src/Client/utils/merkle.ts
+++ b/example/src/Client/utils/merkle.ts
@@ -28,3 +28,5 @@ export const addNotesToMerkleTree = async (notes: Buffer[]) => {
 export const revertToNoteSize = async (noteSize: number) => {
   await notesTree.truncate(noteSize);
 };
+
+export const getNotesTreeSize = () => notesTree.size();


### PR DESCRIPTION
When processing blocks, if the merkle tree is ahead of the current block being processed, we roll it back to the note size at the previous block.