### PR TITLE
update block range max env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ NODE_PORT=8020
 NODE_AUTH_TOKEN=your-auth-token
 BUILD_CACHE=true
 CACHE_PATH=./block-cache
+BLOCK_RANGE_MAX=1000


### PR DESCRIPTION
This env var already exists and sets how many blocks can be streamed in a single request. This (along with cloudflare rate limit) limits number of blocks requested from our hosted server.