### PR TITLE
feat: add finality sequence to prevent reorgs in uploaded `blocks` files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ NODE_AUTH_TOKEN=your-auth-token
 BUILD_CACHE=true
 CACHE_PATH=./block-cache
 BLOCK_RANGE_MAX=1000
+FINALITY_BLOCK_COUNT=30
 
 UPLOAD_BLOCKS=true
 BUCKET_ENDPOINT=https://foo.r2.cloudflarestorage.com

--- a/.env.test
+++ b/.env.test
@@ -4,7 +4,7 @@ NODE_AUTH_TOKEN=your-auth-token
 BUILD_CACHE=true
 CACHE_PATH=./block-cache
 BLOCK_RANGE_MAX=1000
-FINALITY_BLOCK_COUNT=30
+FINALITY_BLOCK_COUNT=1
 
 UPLOAD_BLOCKS=true
 BUCKET_ENDPOINT=https://foo.r2.cloudflarestorage.com

--- a/.env.test
+++ b/.env.test
@@ -4,6 +4,7 @@ NODE_AUTH_TOKEN=your-auth-token
 BUILD_CACHE=true
 CACHE_PATH=./block-cache
 BLOCK_RANGE_MAX=1000
+FINALITY_BLOCK_COUNT=30
 
 UPLOAD_BLOCKS=true
 BUCKET_ENDPOINT=https://foo.r2.cloudflarestorage.com

--- a/src/upload/index.test.ts
+++ b/src/upload/index.test.ts
@@ -11,6 +11,10 @@ import { LightBlock } from "../models/lightstreamer";
 import { createInterface } from "readline";
 
 describe("LightBlockUpload", () => {
+  beforeAll(async () => {
+    await lightBlockCache.open();
+  });
+
   afterAll(async () => {
     jest.resetAllMocks();
     await lightBlockCache.close();

--- a/src/upload/index.ts
+++ b/src/upload/index.ts
@@ -174,8 +174,8 @@ export class LightBlockUpload {
           (currentTimestamp - lastUploadTimestamp) / (1000 * 60 * 60);
         logger.info(
           `${this.bytesToMbRounded(outputFile.bytesWritten)}/` +
-            `${this.bytesToMbRounded(this.chunkSizeBytes)} MB written,` +
-            ` sequence: ${currentSequence}, finalized sequence: ${finalizedSequence}` +
+            `${this.bytesToMbRounded(this.chunkSizeBytes)} MB written, ` +
+            `sequence: ${currentSequence}, finalized sequence: ${finalizedSequence}, ` +
             `hours since last upload: ${hoursSinceLastUpload.toFixed(2)}/` +
             `${this.maxUploadLagMs / (1000 * 60 * 60)}, waiting...`,
         );


### PR DESCRIPTION
Prevents reorgs from showing up in downloadable cache, blocks aren't stored in S3/R2 unless they are lower than `head - FINALITY_BLOCK_COUNT`